### PR TITLE
Android: update dependancies & defaultConfig

### DIFF
--- a/android/capacitor-fcm/build.gradle
+++ b/android/capacitor-fcm/build.gradle
@@ -11,10 +11,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -43,8 +43,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     implementation 'com.google.firebase:firebase-messaging:17.6.0'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 }
 


### PR DESCRIPTION
The upstream capacitor project set the minSdkVersion & targetSdkVersion to 28 (https://github.com/ionic-team/capacitor/blob/master/android/capacitor/build.gradle#L19). 

this PR updates the plugin to match as well as the Android support dependancies to match.