### PR TITLE
Get token was obtaining APN token instead of FCM token

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -60,16 +60,10 @@ public class FCM: CAPPlugin, MessagingDelegate {
     }
     
     @objc func getToken(_ call: CAPPluginCall) {
-        InstanceID.instanceID().instanceID { (result, error) in
-            if let error = error {
-                call.error("Error", error)
-            } else if let result = result {
-                print(result.token)
-                call.success([
-                    "token": result.token
-                ])
-            }
-        }
+        let token = Messaging.messaging().fcmToken ?? ""
+            call.success([
+            "token": token
+        ])
     }
     
     @objc func deleteInstance(_ call: CAPPluginCall) {


### PR DESCRIPTION
In the previous version the getToken method on iOs was getting the APN token instead of the fcm, leading to a "Invalid registration" when tried to send push notifications using registration_ids property.