### PR TITLE
Execute deleteInstanceId on a background thread

### DIFF
--- a/android/capacitor-fcm/src/main/java/io/stewan/capacitor/fcm/FCMPlugin.java
+++ b/android/capacitor-fcm/src/main/java/io/stewan/capacitor/fcm/FCMPlugin.java
@@ -74,13 +74,21 @@ public class FCMPlugin extends Plugin {
 
     @PluginMethod()
     public void deleteInstance(final PluginCall call) {
-        try {
-            FirebaseInstanceId.getInstance().deleteInstanceId();
-            call.success();
-        } catch (IOException e) {
-            e.printStackTrace();
-            call.error("Cant delete Firebase Instance ID", e);
-        }
+        Runnable r = new Runnable() {
+            public void run() {
+                try {
+                    FirebaseInstanceId.getInstance().deleteInstanceId();
+                    call.success();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    call.error("Cant delete Firebase Instance ID", e);
+                }
+            }
+        };
+
+        // Run in background thread since `deleteInstanceId()` is a blocking request.
+        // See https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId#deleteInstanceId()
+        new Thread(r).start();
     }
 
     @PluginMethod()


### PR DESCRIPTION
Calling `deleteInstanceId()` on a background thread is mandatory since this call is blocking.

See https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId#deleteInstanceId()

This cause my App to suspend other network requests that could have called in parallel. The code I submitted solved the issue.

Thanks a lot for the plugin!