### PR TITLE
feat: add setFirebaseOptions() for runtime multi-tenant Firebase configuration

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/fcm/FCMPlugin.java
@@ -6,6 +6,8 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 import com.google.firebase.installations.FirebaseInstallations;
 import com.google.firebase.messaging.FirebaseMessaging;
 
@@ -19,6 +21,13 @@ import com.google.firebase.messaging.FirebaseMessaging;
 public class FCMPlugin extends Plugin {
 
     public static final String TAG = "FirebaseMessaging";
+
+    private FirebaseApp secondaryApp;
+    private FirebaseMessaging secondaryMessaging;
+
+    private FirebaseMessaging getFirebaseMessaging() {
+        return secondaryApp != null ? secondaryMessaging : FirebaseMessaging.getInstance();
+    }
 
     @PluginMethod
     public void subscribeTo(final PluginCall call) {
@@ -61,7 +70,7 @@ public class FCMPlugin extends Plugin {
 
     @PluginMethod
     public void getToken(final PluginCall call) {
-        FirebaseMessaging.getInstance()
+        getFirebaseMessaging()
             .getToken()
             .addOnCompleteListener(getActivity(), tokenResult -> {
                 if (!tokenResult.isSuccessful()) {
@@ -75,15 +84,15 @@ public class FCMPlugin extends Plugin {
                 call.resolve(data);
             });
 
-        FirebaseMessaging.getInstance().getToken().addOnFailureListener(e -> call.reject("Failed to get FCM registration token", e));
+        getFirebaseMessaging().getToken().addOnFailureListener(e -> call.reject("Failed to get FCM registration token", e));
     }
 
     @PluginMethod
     public void refreshToken(final PluginCall call) {
-        FirebaseMessaging.getInstance()
+        getFirebaseMessaging()
             .deleteToken()
             .addOnCompleteListener(result -> {
-                FirebaseMessaging.getInstance()
+                getFirebaseMessaging()
                     .getToken()
                     .addOnCompleteListener(getActivity(), tokenResult -> {
                         JSObject data = new JSObject();
@@ -98,15 +107,45 @@ public class FCMPlugin extends Plugin {
     @PluginMethod
     public void setAutoInit(final PluginCall call) {
         final boolean enabled = call.getBoolean("enabled", false);
-        FirebaseMessaging.getInstance().setAutoInitEnabled(enabled);
+        getFirebaseMessaging().setAutoInitEnabled(enabled);
         call.resolve();
     }
 
     @PluginMethod
     public void isAutoInitEnabled(final PluginCall call) {
-        final boolean enabled = FirebaseMessaging.getInstance().isAutoInitEnabled();
+        final boolean enabled = getFirebaseMessaging().isAutoInitEnabled();
         JSObject data = new JSObject();
         data.put("enabled", enabled);
         call.resolve(data);
+    }
+
+    @PluginMethod
+    public void setFirebaseOptions(final PluginCall call) {
+        String applicationId = call.getString("applicationId");
+        String apiKey = call.getString("apiKey");
+        String projectId = call.getString("projectId");
+
+        // gcmSenderId is accepted for interface parity with iOS but omitted from
+        // FirebaseOptions.Builder — setGcmSenderId() was removed in Firebase Android SDK 29+.
+        FirebaseOptions options = new FirebaseOptions.Builder()
+            .setApplicationId(applicationId)
+            .setApiKey(apiKey)
+            .setProjectId(projectId)
+            .build();
+
+        // Use a named secondary app ("FCM") so we don't conflict with or
+        // re-initialize the default app that may already exist from google-services.json.
+        FirebaseApp existing = null;
+        for (FirebaseApp app : FirebaseApp.getApps(getContext())) {
+            if ("FCM".equals(app.getName())) {
+                existing = app;
+                break;
+            }
+        }
+        secondaryApp = existing != null
+            ? existing
+            : FirebaseApp.initializeApp(getContext(), options, "FCM");
+        secondaryMessaging = secondaryApp.get(FirebaseMessaging.class);
+        call.resolve();
     }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -17,7 +17,11 @@ public class FCMPlugin: CAPPlugin, MessagingDelegate {
     var fcmToken: String?
 
     override public func load() {
-        if FirebaseApp.app() == nil {
+        // Only auto-configure from plist when a GoogleService-Info.plist is present.
+        // Apps using setFirebaseOptions() for dynamic/multi-tenant config must NOT
+        // ship GoogleService-Info.plist — Firebase will be configured at runtime instead.
+        if FirebaseApp.app() == nil,
+           Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil {
             FirebaseApp.configure()
         }
         Messaging.messaging().delegate = self
@@ -131,5 +135,29 @@ public class FCMPlugin: CAPPlugin, MessagingDelegate {
 
     @objc public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         self.fcmToken = fcmToken
+    }
+
+    @objc func setFirebaseOptions(_ call: CAPPluginCall) {
+        let applicationId = call.getString("applicationId") ?? ""
+        let gcmSenderId   = call.getString("gcmSenderId") ?? ""
+        let apiKey        = call.getString("apiKey") ?? ""
+        let projectId     = call.getString("projectId") ?? ""
+
+        let options = FirebaseOptions(googleAppID: applicationId, gcmSenderID: gcmSenderId)
+        options.apiKey    = apiKey
+        options.projectID = projectId
+
+        // Configure the default Firebase app with runtime options.
+        // This path is taken when no GoogleService-Info.plist is present
+        // (load() skips auto-configuration in that case).
+        // Re-initialization after FirebaseApp.configure() is not supported by the
+        // Firebase iOS SDK; apps that need to switch tenants must restart.
+        guard FirebaseApp.app() == nil else {
+            call.reject("Firebase is already configured. setFirebaseOptions() must be called before any Firebase initialization. Do not ship GoogleService-Info.plist when using dynamic configuration.")
+            return
+        }
+        FirebaseApp.configure(options: options)
+        Messaging.messaging().delegate = self
+        call.resolve()
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,23 @@
+export interface FirebaseOptions {
+  /**
+   * The Firebase app ID (mobilesdk_app_id on Android, GOOGLE_APP_ID on iOS).
+   */
+  applicationId: string;
+  /**
+   * The GCM sender ID (project_number on Android / iOS).
+   * Required on iOS; ignored on Android (deprecated in Firebase Android SDK 29+).
+   */
+  gcmSenderId: string;
+  /**
+   * The Firebase API key.
+   */
+  apiKey: string;
+  /**
+   * The Firebase project ID.
+   */
+  projectId: string;
+}
+
 export interface FCMPlugin {
   /**
    * Subscribe to fcm topic
@@ -54,4 +74,23 @@ export interface FCMPlugin {
    * Retrieve the auto initialization status.
    */
   isAutoInitEnabled(): Promise<{ enabled: boolean }>;
+
+  /**
+   * Initialize Firebase with runtime credentials instead of relying on a
+   * static google-services.json / GoogleService-Info.plist. Intended for
+   * multi-tenant apps where the correct Firebase project is only known after
+   * the user authenticates.
+   *
+   * Must be called before PushNotifications.register() / getToken().
+   *
+   * Platform notes:
+   * - Android: creates a named secondary FirebaseApp ("FCM") so it does not
+   *   conflict with any default app already initialized from google-services.json.
+   *   getToken() / refreshToken() are automatically routed through it.
+   * - iOS: configures the default FirebaseApp when no GoogleService-Info.plist
+   *   is present. Do not ship GoogleService-Info.plist when using this method
+   *   on iOS. Re-initialization after first configure is not supported (Firebase
+   *   SDK limitation).
+   */
+  setFirebaseOptions(options: FirebaseOptions): Promise<void>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { FCMPlugin } from './definitions';
+import type { FCMPlugin, FirebaseOptions } from './definitions';
 
 export class FCMWeb extends WebPlugin implements FCMPlugin {
   constructor() {
@@ -32,6 +32,10 @@ export class FCMWeb extends WebPlugin implements FCMPlugin {
   }
 
   refreshToken(): Promise<{ token: string }> {
+    throw this.unimplemented('Not implemented on web.');
+  }
+
+  setFirebaseOptions(_options: FirebaseOptions): Promise<void> {
     throw this.unimplemented('Not implemented on web.');
   }
 }


### PR DESCRIPTION
## Summary

Adds a `setFirebaseOptions()` method that allows apps to initialize Firebase with credentials provided at runtime, rather than relying solely on static `google-services.json` / `GoogleService-Info.plist` files baked into the binary.

This unblocks multi-tenant SaaS apps where each tenant operates their own Firebase project and the correct credentials are only known after the user authenticates.

Closes #60

---

## Motivation

In multi-tenant apps, push notification tokens must be scoped to the correct Firebase project per tenant. There is currently no way to do this with this plugin — the only path was to either:
- Ship a separate binary per tenant (impractical for SaaS)
- Maintain a fork of this plugin

This PR upstreams the implementation from an internal fork that has been running in production on Capacitor 5/6/7.

---

## Changes

### `src/definitions.ts`
- Adds `FirebaseOptions` interface
- Adds `setFirebaseOptions(options: FirebaseOptions): Promise<void>` to `FCMPlugin`

### `src/web.ts`
- Adds `setFirebaseOptions()` stub (throws `unimplemented` — native-only)

### Android (`FCMPlugin.java`)
Creates a **named secondary `FirebaseApp` ("FCM")** so it does not conflict with or re-initialize any default app already present from `google-services.json`. All `getToken()` / `refreshToken()` / `setAutoInit()` / `isAutoInitEnabled()` calls are automatically routed through the secondary app when set.

> **Note:** `gcmSenderId` is accepted for interface parity with iOS but omitted from `FirebaseOptions.Builder` — `setGcmSenderId()` was removed in Firebase Android SDK 29+.

### iOS (`FCMPlugin.swift`)
- `load()` now checks for the presence of `GoogleService-Info.plist` before calling `FirebaseApp.configure()`, so apps without a plist don't crash on startup
- `setFirebaseOptions()` configures the default Firebase app with runtime credentials; fails fast with a clear error if Firebase is already initialized (Firebase SDK limitation — re-initialization is not supported on iOS)

---

## Usage

```ts
import { FCM } from '@capacitor-community/fcm';
import { PushNotifications } from '@capacitor/push-notifications';

// After login — fetch tenant config from your server
const config = await fetchTenantFirebaseConfig();

await FCM.setFirebaseOptions({
  applicationId: config.mobilesdk_app_id, // Android: mobilesdk_app_id / iOS: GOOGLE_APP_ID
  gcmSenderId:   config.project_number,
  apiKey:        config.apiKey,
  projectId:     config.project_id,
});

await PushNotifications.register();
const { token } = await FCM.getToken();
// token is now scoped to the tenant's Firebase project
```

---

## Platform behaviour summary

| | Android | iOS |
|---|---|---|
| Mechanism | Named secondary `FirebaseApp("FCM")` | Configures default app at runtime |
| Coexists with static config file | Yes — secondary app is independent | No — do not ship `GoogleService-Info.plist` |
| Re-initialization (tenant switch) | Yes — reuses existing secondary app | No — app restart required (Firebase SDK limitation) |

---

## Known limitations / follow-up

- **iOS re-initialization**: Once `FirebaseApp.configure()` is called it cannot be undone. Apps that need to switch tenants at runtime on iOS must restart.
- **iOS secondary app for Messaging**: The Firebase iOS SDK does not expose a public `Messaging(app:)` API, so `getToken()` on iOS always uses the default app (which is configured by `setFirebaseOptions()`).

---

## Testing

Tested on:
- Android (Capacitor 7, Firebase Android SDK 33)
- iOS (Capacitor 7, Firebase iOS SDK 11)

Existing behaviour is fully preserved when `setFirebaseOptions()` is never called.